### PR TITLE
Add file identity checking to posttroll_adder

### DIFF
--- a/examples/posttroll_adder.yaml
+++ b/examples/posttroll_adder.yaml
@@ -14,6 +14,14 @@ geoserver_target_dir: /opt/geoserver/data_dir
 #   supported by Geoserver) in the image files.
 write_wkt: 'PROJCS["World_Eckert_IV",GEOGCS["WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["degree",0.017453292519943295],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]],PROJECTION["Eckert_IV"],PARAMETER["semi_minor",6378137.0],PARAMETER["central_meridian",0.0],UNIT["m",1.0],AXIS["x",EAST],AXIS["y",NORTH],AUTHORITY["EPSG","54012"]]'
 
+# This will be used, if also the below option is set, to check for
+#   identity of already existing images on Geoserver
+# file_pattern: "{start_time:%Y%m%d_%H%M}_{platform_name}_{areaname}_{productname}.{format}"
+# Check for other file name parts for identity if there already is a file
+#   within the given time distance.  Do not add the image if all other parts match
+# identity_check_seconds: 300  # 5 minutes
+
+
 # Configuration for incoming messages
 topics:
   - /topic/1

--- a/georest/tests/test_utils.py
+++ b/georest/tests/test_utils.py
@@ -138,6 +138,7 @@ def test_run_posttroll_adder(connect_to_gs_catalog, write_wkt, add_granule,
     config = {"workspace": "satellite",
               "topics": ["/topic1", "/topic2"],
               "layers": {},
+              "file_pattern": "{base_filename}.{format}"
               }
     convert_file_path.return_value = "/mnt/data/image.tif"
     msg = mock.MagicMock(data={"productname": "airmass", "uri": "/path/to/image.tif"})

--- a/georest/tests/test_utils.py
+++ b/georest/tests/test_utils.py
@@ -34,6 +34,7 @@ def test_write_wkt():
 
     config = {"write_wkt": "mock WKT string"}
     with tempfile.TemporaryDirectory() as tempdir:
+        config["exposed_target_dir"] = tempdir
         tif_fname = os.path.join(tempdir, "image.tif")
         write_wkt(config, tif_fname)
         prj_fname = os.path.join(tempdir, "image.prj")

--- a/georest/utils.py
+++ b/georest/utils.py
@@ -241,10 +241,16 @@ def _process_message(cat, config, msg):
     """Process posttroll message."""
     prod = msg.data["productname"]
     store = config["layers"].get(prod)
+    workspace = config["workspace"]
     config["store"] = store
+    identity_check_seconds = config.get("identity_check_seconds")
+
     fname = convert_file_path(config, msg.data["uri"])
     if store is None:
         logger.error("No layer name for '%s'", prod)
+        return
+    if file_in_granules(cat, workspace, store, fname,
+                        identity_check_seconds, config["file_pattern"]):
         return
     # Write WKT to file if configured
     write_wkt(config, fname)

--- a/georest/utils.py
+++ b/georest/utils.py
@@ -234,6 +234,8 @@ def _posttroll_adder_loop(config, Subscribe, restart_timeout):
                 latest_message_time = dt.datetime.utcnow()
                 _process_message(cat, config.copy(), msg)
         except KeyboardInterrupt:
+            pass
+        finally:
             return True
 
 


### PR DESCRIPTION
This PR adds a possibility to check to Posttroll adder that the new granule isn't already in the layer.