### PR TITLE
Catch ValueError raised by trollsift.parse for invalid filenames

### DIFF
--- a/georest/tests/test_utils.py
+++ b/georest/tests/test_utils.py
@@ -10,6 +10,8 @@
 
 from unittest import mock
 
+import pytest
+
 
 def test_read_config():
     """Test reading a config file."""
@@ -124,6 +126,10 @@ def test_file_in_granules(georest):
     assert not file_in_granules(
         cat, workspace, store, file_path, identity_check_seconds, file_pattern)
 
+    # Filepattern and filename do not match
+    file_path = "/path/to/20200818_1200_europe_airmass.l1b"
+    with pytest.raises(ValueError):
+        file_in_granules(cat, workspace, store, file_path, identity_check_seconds, file_pattern)
 
 @mock.patch("georest.utils.file_in_granules")
 @mock.patch("georest.utils.convert_file_path")

--- a/georest/utils.py
+++ b/georest/utils.py
@@ -232,7 +232,10 @@ def _posttroll_adder_loop(config, Subscribe, restart_timeout):
                     continue
                 logger.debug("New message received: %s", str(msg))
                 latest_message_time = dt.datetime.utcnow()
-                _process_message(cat, config.copy(), msg)
+                try:
+                    _process_message(cat, config.copy(), msg)
+                except ValueError:
+                    logger.warning("Filename pattern doesn't match.")
         except KeyboardInterrupt:
             pass
         finally:


### PR DESCRIPTION
This PR catches a `ValueError` raised by `trollsift.parse()` when the filename and filepattern do not match.