### PR TITLE
Fix posttroll adder failing silently if file_pattern was not in config

### DIFF
--- a/georest/tests/test_utils.py
+++ b/georest/tests/test_utils.py
@@ -146,7 +146,6 @@ def test_run_posttroll_adder(connect_to_gs_catalog, write_wkt, add_granule,
     config = {"workspace": "satellite",
               "topics": ["/topic1", "/topic2"],
               "layers": {},
-              "file_pattern": "{base_filename}.{format}"
               }
     convert_file_path.return_value = "/mnt/data/image.tif"
     msg = mock.MagicMock(data={"productname": "airmass", "uri": "/path/to/image.tif"})
@@ -171,10 +170,11 @@ def test_run_posttroll_adder(connect_to_gs_catalog, write_wkt, add_granule,
         config["layers"]["airmass"],
         convert_file_path.return_value,
         None,  # No "identity_check_seconds" set
-        config["file_pattern"])
+        None)  # No "file_pattern" in config
 
-    # Set "identity_check_seconds"
+    # Set "identity_check_seconds" and "file_pattern" to config
     config["identity_check_seconds"] = 60
+    config["file_pattern"] = "{base_filename}.{format}"
     run_posttroll_adder(config, Subscribe)
     file_in_granules.assert_called_with(
         connect_to_gs_catalog.return_value,
@@ -194,7 +194,6 @@ def test_posttroll_adder_loop_return_value(connect_to_gs_catalog, process_messag
     config = {"workspace": "satellite",
               "topics": ["/topic1", "/topic2"],
               "layers": {"airmass": "airmass_layer_name"},
-              "file_pattern": "{base_filename}.{format}",
               }
     msg = mock.MagicMock(data={"productname": "airmass", "uri": "/path/to/image.tif"})
     Subscribe = mock.MagicMock()

--- a/georest/utils.py
+++ b/georest/utils.py
@@ -160,7 +160,7 @@ def file_in_granules(cat, workspace, store, file_path, identity_check_seconds, f
     file_pattern: Trollsift filename pattern.  If *identity_check_seconds* match,
                   also other filename parts are compared.  If all match, return True.
     """
-    if identity_check_seconds is not None:
+    if identity_check_seconds is not None and file_pattern is not None:
         store_obj = cat.get_store(store, workspace)
         coverage = georest.get_layer_coverage(cat, store, store_obj)
         granules = georest.get_layer_granules(cat, coverage, store_obj)
@@ -253,13 +253,14 @@ def _process_message(cat, config, msg):
     workspace = config["workspace"]
     config["store"] = store
     identity_check_seconds = config.get("identity_check_seconds")
+    file_pattern = config.get("file_pattern")
 
     fname = convert_file_path(config, msg.data["uri"])
     if store is None:
         logger.error("No layer name for '%s'", prod)
         return
     if file_in_granules(cat, workspace, store, fname,
-                        identity_check_seconds, config["file_pattern"]):
+                        identity_check_seconds, file_pattern):
         return
     # Write WKT to file if configured
     write_wkt(config, fname)


### PR DESCRIPTION
The `posttroll_adder.py` was failing silently if the `file_pattern` option was not set in the config. This PR fixes this so that the adder will work properly.