### PR TITLE
Add a possibility to set CacheAgeMax HTTP response value

### DIFF
--- a/examples/create_layers.yaml
+++ b/examples/create_layers.yaml
@@ -22,7 +22,7 @@ exposed_base_dir: /path/to/somewhere
 #   config.
 write_wkt: 'PROJCS["World_Eckert_IV",GEOGCS["WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["degree",0.017453292519943295],AXIS["Longitude",EAST],AXIS["Latitude",NORTH]],PROJECTION["Eckert_IV"],PARAMETER["semi_minor",6378137.0],PARAMETER["central_meridian",0.0],UNIT["m",1.0],AXIS["x",EAST],AXIS["y",NORTH],AUTHORITY["EPSG","54012"]]'
 
-# Common items to all layers
+# Common items to all layers.  These can be overridden layer-by-layer
 common_items:
   sensor_title: SEVIRI
   sensor_name: seviri
@@ -34,6 +34,8 @@ common_items:
   layer_pattern: "satellite_{orbit_name}_{area_name}_{sensor_name}_{product_name}"
   # If "title" is not set for a layer, use this pattern instead
   title_pattern: "Satellite {orbit_title} {area_title} {sensor_title} {product_title}"
+  # Uncomment to set cache age setting (in seconds) for HTTP header responses
+  # cache_age_max: 86400
 
 # Property files to be sent.
 properties:

--- a/georest/__init__.py
+++ b/georest/__init__.py
@@ -18,7 +18,7 @@ import trollsift
 from geoserver.catalog import Catalog, FailedRequestError
 from geoserver.support import DimensionInfo
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 # These layer attributes can be set
 LAYER_ATTRIBUTES = ["title", "abstract", "keywords"]
@@ -111,6 +111,8 @@ def add_layer_metadata(cat, workspace, layer_name, time_dim, meta):
             setattr(coverage, attribute, attr)
 
     coverage = _add_time_dimension(coverage, time_dim)
+    coverage = _add_cache_age_max(coverage, meta.get("cache_age_max", None))
+
     # Save the added metadata
     cat.save(coverage)
     logger.info("Metadata written for layer '%s' on workspace '%s'",
@@ -166,6 +168,18 @@ def _add_time_dimension(coverage, time_dim):
         None,
         nearestMatchEnabled=time_dim["nearestMatchEnabled"])
     metadata['time'] = time_info
+    coverage.metadata = metadata
+
+    return coverage
+
+
+def _add_cache_age_max(coverage, cache_age_max):
+    """Add maximum cache age parameter to HTTP responses."""
+    if cache_age_max is None:
+        return coverage
+    metadata = coverage.metadata.copy()
+    metadata["cacheAgeMax"] = str(cache_age_max)
+    metadata["cachingEnabled"] = "true"
     coverage.metadata = metadata
 
     return coverage


### PR DESCRIPTION
With this PR it is possible to set the `Publishing` -> `HTTP Settings` -> `Caching Settings` -> `Response Cache Headers` and the associated `Cache Time` by setting `cache_age_max` config item to an integer value of seconds in `common_items` or individually layer-by-layer.

Also raises the version number to 0.7.0.

Closes #10 