### PR TITLE
Make it possible to define Geoserver login credentials in environment variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+exclude: '^$'
+fail_fast: false
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: flake8
+      additional_dependencies: [flake8-docstrings, flake8-debugger, flake8-bugbear]

--- a/examples/create_layers.yaml
+++ b/examples/create_layers.yaml
@@ -1,6 +1,8 @@
 # Connection and workspace settings
 host: http://<geoserver URL>/geoserver/rest/
+# Also possible via GEOSERVER_USER env variable. If neither are given, the default "admin" will be used
 user: <geoserver username>
+# Also possible via GEOSERVER_PASSWORD env variable. If neither are given, the default "geoserver" will be used
 passwd: <geoserver password>
 # The workspace will be created if it doesn't exist
 workspace: <workspace name>

--- a/examples/granules.yaml
+++ b/examples/granules.yaml
@@ -1,6 +1,8 @@
 # Connection and workspace settings
 host: http://<geoserver URL>/geoserver/rest/
+# Also possible via GEOSERVER_USER env variable. If neither are given, the default "admin" will be used
 user: <geoserver username>
+# Also possible via GEOSERVER_PASSWORD env variable. If neither are given, the default "geoserver" will be used
 passwd: <geoserver password>
 workspace: <name of the workspace>
 store: <name of the layer>

--- a/examples/posttroll_adder.yaml
+++ b/examples/posttroll_adder.yaml
@@ -1,6 +1,8 @@
 # Connection and workspace settings
 host: http://<geoserver URL>/geoserver/rest/
+# Also possible via GEOSERVER_USER env variable. If neither are given, the default "admin" will be used
 user: <geoserver username>
+# Also possible via GEOSERVER_PASSWORD env variable. If neither are given, the default "geoserver" will be used
 passwd: <geoserver password>
 workspace: <name of the workspace>
 

--- a/georest/tests/test_utils.py
+++ b/georest/tests/test_utils.py
@@ -19,13 +19,62 @@ def test_read_config():
     import tempfile
     import os
 
-    config = """foo: bar"""
+    config = """
+        foo: bar
+        user: user1
+        passwd: passwd1
+    """
     with tempfile.TemporaryDirectory() as tempdir:
         config_file = os.path.join(tempdir, "config.yaml")
         with open(config_file, "w") as fid:
             fid.write(config)
         res = read_config(config_file)
         assert res["foo"] == "bar"
+        assert res["user"] == "user1"
+        assert res["passwd"] == "passwd1"
+
+
+def test_read_config_credentials_in_env():
+    """Test reading a config file when user/passwd are given in environment variables."""
+    from georest.utils import read_config
+    import tempfile
+    import os
+
+    os.environ["GEOSERVER_USER"] = "user1"
+    os.environ["GEOSERVER_PASSWORD"] = "passwd1"
+    config = """
+        foo: bar
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        config_file = os.path.join(tempdir, "config.yaml")
+        with open(config_file, "w") as fid:
+            fid.write(config)
+        res = read_config(config_file)
+        assert res["foo"] == "bar"
+        assert res["user"] == "user1"
+        assert res["passwd"] == "passwd1"
+
+
+def test_read_config_default_credentials():
+    """Test reading a config file when user/passwd are not given."""
+    from georest.utils import read_config
+    import tempfile
+    import os
+
+    os.environ.pop("GEOSERVER_USER", None)
+    os.environ.pop("GEOSERVER_PASSWORD", None)
+
+    config = """
+        foo: bar
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        config_file = os.path.join(tempdir, "config.yaml")
+        with open(config_file, "w") as fid:
+            fid.write(config)
+        res = read_config(config_file)
+        assert res["foo"] == "bar"
+        assert res["user"] == "admin"
+        assert res["passwd"] == "geoserver"
 
 
 def test_write_wkt():
@@ -202,17 +251,17 @@ def test_posttroll_adder_loop_return_value(connect_to_gs_catalog, process_messag
     # Timeout occurs
     restart_timeout = -1.0
     res = _posttroll_adder_loop(config, Subscribe, restart_timeout)
-    assert res == False
+    assert res is False
 
     # Unhandled exception
     process_message.side_effect = IOError
     res = _posttroll_adder_loop(config, Subscribe, None)
-    assert res == False
+    assert res is False
 
     # KeyboardInterrupt is the only that should return True
     process_message.side_effect = KeyboardInterrupt
     res = _posttroll_adder_loop(config, Subscribe, None)
-    assert res == True
+    assert res is True
 
 
 @mock.patch("georest.utils._process_message")

--- a/georest/utils.py
+++ b/georest/utils.py
@@ -28,6 +28,10 @@ def read_config(fname):
     """Read configuration file."""
     with open(fname, 'r') as fid:
         config = yaml.load(fid, yaml.SafeLoader)
+    if "user" not in config:
+        config["user"] = os.environ.get("GEOSERVER_USER", "admin")
+    if "passwd" not in config:
+        config["passwd"] = os.environ.get("GEOSERVER_PASSWORD", "geoserver")
     return config
 
 
@@ -243,7 +247,7 @@ def _posttroll_adder_loop(config, Subscribe, restart_timeout):
         except KeyboardInterrupt:
             return_value = True
         finally:
-            return return_value
+            return return_value  # noqa:B012
 
 
 def _process_message(cat, config, msg):


### PR DESCRIPTION
Make it possible to define Geoserver login credentials in environment variables. If the credentials are neither in the config or environment variables, use the Geoserver default values.