### PR TITLE
Change S3 granule addition

### DIFF
--- a/examples/create_s3_layers.yml
+++ b/examples/create_s3_layers.yml
@@ -44,16 +44,16 @@ layers:
   - product_name: airmass
     product_title: Airmass
     # The prototype image should be available in a bucket
-    prototype_image: https://<bucket>.<bucket host>/20170920_0000_MTGI-1_EPSG3035_airmass.tif
+    image_url: https://<bucket>.<bucket host>/20170920_0000_MTGI-1_EPSG3035_airmass.tif
     # The optional abstract text can be inline, or available in a file
     abstract: /path/to/abstracts/abstract_airmass.txt
   - product_name: night_microphysical
     product_title: Night microphysical, night-side only
-    prototype_image: https://<bucket>.<bucket host>/20170920_0000_MTGI-1_EPSG3035_night_microphysical.tif
+    image_url: https://<bucket>.<bucket host>/20170920_0000_MTGI-1_EPSG3035_night_microphysical.tif
     abstract: /path/to/abstracts/abstract_airmass.txt
   - product_name: true_color
     product_title: True color, day-side only
-    prototype_image: https://<bucket>.<bucket host>/20170920_0000_MTGI-1_EPSG3035_true_color.tif
+    image_url: https://<bucket>.<bucket host>/20170920_0000_MTGI-1_EPSG3035_true_color.tif
     abstract: /path/to/abstracts/abstract_airmass.txt
 
 log_config:

--- a/georest/__init__.py
+++ b/georest/__init__.py
@@ -229,7 +229,7 @@ def add_s3_granule(config, meta):
     headers = {'Content-type': 'text/plain'}
     auth = (config['user'], config['passwd'])
     req = requests.post(url, data=data, headers=headers, auth=auth)
-    if req.status_code == requests.codes.ok:
+    if req.status_code == requests.codes.accepted:
         logger.info(f"Granule '{data}' added to '{meta['workspace']}:{meta['layer_name']}'")
     else:
         logger.error(f"Adding granule '{data}' failed with status code {req.status_code}")

--- a/georest/__init__.py
+++ b/georest/__init__.py
@@ -232,7 +232,7 @@ def add_s3_granule(config, meta):
     if req.status_code == requests.codes.ok:
         logger.info(f"Granule '{data} added to '{meta['workspace']}:{meta['layer_name']}'")
     else:
-        logger.error("Adding granule '{data}' failed with status code {req.status_code}")
+        logger.error(f"Adding granule '{data}' failed with status code {req.status_code}")
 
 
 def _configure_coverage(config, meta):

--- a/georest/__init__.py
+++ b/georest/__init__.py
@@ -230,7 +230,7 @@ def add_s3_granule(config, meta):
     auth = (config['user'], config['passwd'])
     req = requests.post(url, data=data, headers=headers, auth=auth)
     if req.status_code == requests.codes.ok:
-        logger.info(f"Granule '{data} added to '{meta['workspace']}:{meta['layer_name']}'")
+        logger.info(f"Granule '{data}' added to '{meta['workspace']}:{meta['layer_name']}'")
     else:
         logger.error(f"Adding granule '{data}' failed with status code {req.status_code}")
 

--- a/georest/tests/test_geoserver.py
+++ b/georest/tests/test_geoserver.py
@@ -407,7 +407,7 @@ def test_create_s3_layers(requests):
             {
                 "product_name": "product_name",
                 "product_title": "product_title",
-                "prototype_image": "https://bucket.host/image.tif",
+                "image_url": "https://bucket.host/image.tif",
                 "abstract": "abstract",
             }
         ]
@@ -428,10 +428,11 @@ def test_create_s3_layers(requests):
                 'headers': {'Content-type': 'text/plain'},
                 'auth': ('user', 'passwd')}
     assert second_call.kwargs == expected
-    third_call = requests.mock_calls[2]
+    # The next two calls are checking the request status, skip those
+    last_call = requests.mock_calls[-1]
     url = 'http://host/workspaces/workspace/coveragestores/layer_pattern/coverages'
-    assert third_call.args[0] == url
+    assert last_call.args[0] == url
     expected = {'data': 'coverage_template',
                 'headers': {'Content-type': 'text/xml'},
                 'auth': ('user', 'passwd')}
-    assert third_call.kwargs == expected
+    assert last_call.kwargs == expected

--- a/georest/utils.py
+++ b/georest/utils.py
@@ -278,7 +278,7 @@ def _process_message(cat, config, msg):
             'host': config['host'],
             'workspace': workspace,
             'layer_name': store,
-            'prototype_image': fname,
+            'image_url': fname,
         }
         georest.add_s3_granule(config, meta)
     else:


### PR DESCRIPTION
This PR changes the S3 granule addition internals a bit, and changes the prototype image config item in S3-based layer creation from `prototype_image` to `image_url`. Also, logging for the granule addition is now added based on the request status.