### PR TITLE
Add config options for additional styles

### DIFF
--- a/examples/create_layers.yaml
+++ b/examples/create_layers.yaml
@@ -39,13 +39,18 @@ common_items:
   # Uncomment to set cache age setting (in seconds) for HTTP header responses
   # cache_age_max: 86400
 
-# Set the default style to the layer. The style should already exist
-default_style:
+# Set the default and additional styles to the layer. The styles should already exist
+style:
   null
-  # Name of style
-  # name: raster
-  # # Workspace of the style
-  # workspace: Radar
+  # default_style:
+  #   # Name of style
+  #   # name: raster
+  #   # # Workspace of the style
+  #   # workspace: null
+  # additional_styles:  # at least name must be given
+  #   # - name: "raster"
+  #   #   workspace: null
+  #   # - name: "Radar dbz winter"
 
 # Property files to be sent.
 properties:

--- a/georest/__init__.py
+++ b/georest/__init__.py
@@ -99,7 +99,7 @@ def _create_layers(config, cat, property_file):
         utils.write_wkt_for_files(config, layer_directories[layer_name])
 
         if _create_layer(cat, workspace, layer_name, property_file):
-            if not add_layer_metadata(cat, workspace, layer_name, dimensions, meta, style=config.get("default_style")):
+            if not add_layer_metadata(cat, workspace, layer_name, dimensions, meta, style=config.get("style")):
                 continue
             # Delete the empty image from database (does not remove the file)
             for fname in config["properties"].get("files", []):
@@ -131,7 +131,18 @@ def add_layer_metadata(cat, workspace, layer_name, dimensions, meta, style=None)
     if style is not None:
         # Add default style for layer
         layer = cat.get_layer(layer_name)
-        layer._set_default_style(cat.get_style(style["name"], workspace=style["workspace"]))
+
+        layer._set_default_style(
+            cat.get_style(style["default_style"]["name"], workspace=style["default_style"].get("workspace"))
+        )
+
+        # Set additional styles
+        if style.get("additional_styles"):
+            gs_styles = []
+            for style_ in style["additional_styles"]:
+                gs_styles.append(cat.get_style(style_["name"], workspace=style_.get("workspace")))
+            layer._set_alternate_styles(gs_styles)
+
         cat.save(layer)
     logger.info(
         "Metadata written for layer '%s' on workspace '%s'", layer_name, workspace

--- a/georest/tests/test_geoserver.py
+++ b/georest/tests/test_geoserver.py
@@ -104,7 +104,10 @@ CREATE_LAYERS_CONFIG = {
 }
 
 CREATE_LAYERS_WITH_STYLE_CONFIG = deepcopy(CREATE_LAYERS_CONFIG)
-CREATE_LAYERS_WITH_STYLE_CONFIG["default_style"] = {"name": "style", "workspace": "workspace"}
+CREATE_LAYERS_WITH_STYLE_CONFIG["style"] = {
+    "default_style": {"name": "style", "workspace": "workspace"},
+    "additional_styles": [{"name": "additional_style1", "workspace": "workspace"}, {"name": "additional_style2", "workspace": "workspace"}],
+}
 
 
 @mock.patch("georest.DimensionInfo")
@@ -186,7 +189,10 @@ def test_create_layers_with_style(connect_to_gs_catalog):
         create_layers(config.copy())
 
     assert "call.get_style('style', workspace='workspace')" in str(cat.mock_calls)
+    assert "call.get_style('additional_style1', workspace='workspace')" in str(cat.mock_calls)
+    assert "call.get_style('additional_style1', workspace='workspace')" in str(cat.mock_calls)
     assert "_set_default_style" in str(cat.mock_calls)
+    assert "_set_alternate_styles" in str(cat.mock_calls)
 
 
 @mock.patch("georest.delete_granule")

--- a/georest/tests/test_geoserver.py
+++ b/georest/tests/test_geoserver.py
@@ -190,7 +190,7 @@ def test_create_layers_with_style(connect_to_gs_catalog):
 
     assert "call.get_style('style', workspace='workspace')" in str(cat.mock_calls)
     assert "call.get_style('additional_style1', workspace='workspace')" in str(cat.mock_calls)
-    assert "call.get_style('additional_style1', workspace='workspace')" in str(cat.mock_calls)
+    assert "call.get_style('additional_style2', workspace='workspace')" in str(cat.mock_calls)
     assert "_set_default_style" in str(cat.mock_calls)
     assert "_set_alternate_styles" in str(cat.mock_calls)
 


### PR DESCRIPTION
Add possibility to specify additional styles for the layer. The style section of the config should now be e.g.

```yaml
style:
  default_style:
    name: "Radar dbz summer"
    workspace: null
  additional_styles:
    - name: "raster"
    - name: "Radar dbz winter"
```
For all style items, the `workspace` is optional and defaults to empty. If the style section is not empty (`style: null`), default style needs to be given but additional styles are optional.
