### PR TITLE
Add possibility to set projection policy

### DIFF
--- a/examples/create_layers.yaml
+++ b/examples/create_layers.yaml
@@ -38,6 +38,8 @@ common_items:
   title_pattern: "Satellite {orbit_title} {area_title} {sensor_title} {product_title}"
   # Uncomment to set cache age setting (in seconds) for HTTP header responses
   # cache_age_max: 86400
+  # Set projection policy for the layer
+  projection_policy: FORCE_DECLARED
 
 # Set the default and additional styles to the layer. The styles should already exist
 style:

--- a/georest/__init__.py
+++ b/georest/__init__.py
@@ -226,8 +226,8 @@ def _add_projection_policy(coverage, projection_policy):
     # ugly hack to fix a (possible) bug in geoserver-restconfig
     # differences in names for projection_policy/ProjectionPolicy
     # make it so that the projection_policy is not written in the message
-    coverage.dirty["ProjectionPolicy"] = projection_policy
-    coverage.writers["ProjectionPolicy"] = write_string("projectionPolicy")
+    coverage.dirty["projectionPolicy"] = projection_policy
+    coverage.writers["projectionPolicy"] = write_string("projectionPolicy")
 
     return coverage
 

--- a/georest/tests/test_geoserver.py
+++ b/georest/tests/test_geoserver.py
@@ -86,7 +86,7 @@ def _create_extra_files(tempdir, files):
 CREATE_LAYERS_CONFIG = {
     "host": "host",
     "workspace": "workspace",
-    "common_items": {"cache_age_max": 86400},
+    "common_items": {"cache_age_max": 86400, "projection_policy": "FORCE_DECLARED"},
     "properties": {"foo": {"bar": "baz"}},
     "dimensions": {
         "time_dimension": {
@@ -137,6 +137,7 @@ def test_create_layers(connect_to_gs_catalog, DimensionInfo):
     cat.save.assert_called_once()
     assert "'cacheAgeMax', '86400'" in str(coverage.mock_calls)
     assert "'cachingEnabled', 'true'" in str(coverage.mock_calls)
+    assert "'ProjectionPolicy', 'FORCE_DECLARED'" in str(coverage.mock_calls)
 
 
 @mock.patch("georest.DimensionInfo")

--- a/georest/tests/test_geoserver.py
+++ b/georest/tests/test_geoserver.py
@@ -137,7 +137,7 @@ def test_create_layers(connect_to_gs_catalog, DimensionInfo):
     cat.save.assert_called_once()
     assert "'cacheAgeMax', '86400'" in str(coverage.mock_calls)
     assert "'cachingEnabled', 'true'" in str(coverage.mock_calls)
-    assert "'ProjectionPolicy', 'FORCE_DECLARED'" in str(coverage.mock_calls)
+    assert "'projectionPolicy', 'FORCE_DECLARED'" in str(coverage.mock_calls)
 
 
 @mock.patch("georest.DimensionInfo")


### PR DESCRIPTION
Add possibility to set projection policy (options `FORCE_DECLARED`,`REPROJECT_TO_DECLARED` or `NONE`) in config with:

```yaml
common_items:
  projection_policy: FORCE_DECLARED # or NONE or REPROJECT_TO_DECLARED

```

The function to set this is a bit hacky, since just setting the `coverage.projection_policy` attribute does not seem to work, most likely due to inconsistent naming in the [geoserver-restconfig object definition](https://github.com/GeoNode/geoserver-restconfig/blob/ca13727991d0b9d520c5ccefc65cf60f6fe6dc51/src/geoserver/resource.py#L229) (attribute name is `projection_policy` but it should be `projectionPolicy` to be written in REST message).